### PR TITLE
Add Uncertainty-Aware RWM (RWM-U) paper to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,20 @@ Curated database of foundation models for robotics
 
 ---
 
+### **Uncertainty-Aware RWM (RWM-U)**
+*I, P, A → I', U (Image, Proprioception, Actions → Future Images, Uncertainty)*
+
+* **Website**: [sites.google.com/view/uncertainty-aware-rwm](https://sites.google.com/view/uncertainty-aware-rwm)
+* **Paper**: [Offline Robotic World Model: Learning Robotic Policies without a Physics Simulator](https://arxiv.org/abs/2504.16680)
+* **Code**: [leggedrobotics/robotic_world_model_lite](https://github.com/leggedrobotics/robotic_world_model_lite)
+* **Notes**:
+    *   Released April 2025.
+    *   Extends Robotic World Model (RWM) with ensemble-based epistemic uncertainty estimation.
+    *   Enables fully offline model-based reinforcement learning (MBRL) on real robots by penalizing high-risk imagined transitions (MOPO-PPO).
+    *   Evaluated on real quadruped and humanoid robots for manipulation and locomotion.
+
+---
+
 ### **OpenVLA**
 *I, L → A (Image, Language → Actions)*
 


### PR DESCRIPTION
Added the "Uncertainty-Aware RWM (RWM-U)" paper to the foundation models list in `README.md` in response to Issue #33.
The entry includes all relevant links (website, paper, code) and a summary of the model's key features (epistemic uncertainty estimation, offline MBRL).
Verified the information against the project website and citation.

---
*PR created automatically by Jules for task [11621039678559054096](https://jules.google.com/task/11621039678559054096) started by @cagbal*