### PR TITLE
Add LingBot-VLA and update GR00T N1.6 details

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Curated database of foundation models for robotics
     *   Developed by Robbyant.
     *   Pre-trained on 20,000 hours of real-world multi-embodiment robot data (9 dual-arm configurations).
     *   Achieves clear superiority on 100 real-world tasks across 3 platforms.
-    *   Empirically validates that VLA performance scales with data volume without saturation.
+    *   Empirically validates **Scaling Laws** for VLAs: performance scales with data volume without saturation.
     *   Highly efficient training throughput.
 
 ---


### PR DESCRIPTION
This PR addresses open issues #39 and #40 by adding the LingBot-VLA paper (RobbyAnt VLA) to the main list and updating the existing Nvidia Isaac GR00T N1.6 entry with code, weights, and research page links.

---
*PR created automatically by Jules for task [17208109288329677167](https://jules.google.com/task/17208109288329677167) started by @cagbal*