### PR TITLE
Add DynamicVLA paper to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Curated database of foundation models for robotics
 
 ## Main list 👇
 
+### **DynamicVLA**
+*I, L → A (Image, Language → Actions)*
+
+* **Paper**: [DynamicVLA: A Vision-Language-Action Model for Dynamic Object Manipulation](https://arxiv.org/abs/2601.22153)
+* **Website**: [infinitescript.com/project/dynamic-vla](https://www.infinitescript.com/project/dynamic-vla/)
+* **Code**: [hzxie/DynamicVLA](https://github.com/hzxie/DynamicVLA)
+* **Dataset**: [Hugging Face](https://huggingface.co/datasets/hzxie/DOM)
+* **Notes**:
+    *   Released Jan 2026.
+    *   Enables open-ended dynamic object manipulation by pairing a compact 0.4B VLM with low-latency strategies.
+    *   Uses **Latent-Aware Action Streaming** and **Continuous Inference** to remove pauses and ensure seamless transitions.
+    *   Introduces the **Dynamic Object Manipulation (DOM)** benchmark with 2.8K scenes and 206 objects.
+    *   Outperforms $\pi_0$ (0.5) and SmolVLA on dynamic tasks.
+
+---
+
 ### **DeFM**
 *D → Representations (Depth → Representations)*
 


### PR DESCRIPTION
Add DynamicVLA paper to README.md as requested in issue #44.
The entry includes the paper link, website, code, dataset, and notes derived from the project page.
The entry is placed at the top of the Main list, following the reverse chronological order (Jan 2026, ArXiv 2601.22153).


---
*PR created automatically by Jules for task [17152865347950943524](https://jules.google.com/task/17152865347950943524) started by @cagbal*