### PR TITLE
Add DreamZero to README (Issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ Curated database of foundation models for robotics
 
 ## Main list 👇
 
+### **DreamZero**
+*I, L → A, V (Image, Language → Actions, Video)*
+* **Website**: [dreamzero0.github.io](https://dreamzero0.github.io/)
+* **Paper**: [DreamZero: World Action Models Are Zero-Shot Policies](https://dreamzero0.github.io/DreamZero.pdf)
+* **Code**: [dreamzero0/dreamzero](https://github.com/dreamzero0/dreamzero)
+* **Weights**: [Hugging Face](https://huggingface.co/GEAR-Dreams/DreamZero-DROID)
+* **Notes**:
+    *   Released Feb 2026.
+    *   World Action Model (WAM) that jointly predicts actions and videos.
+    *   Achieves strong zero-shot generalization to new tasks and environments (over 2x improvement vs VLAs).
+    *   Demonstrates efficient cross-embodiment transfer (adapts to new robot with 30 mins of play data).
+    *   Enables real-time closed-loop control at 7Hz via model and system optimizations (DreamZero-Flash).
+
+---
+
 ### **DeFM**
 *D → Representations (Depth → Representations)*
 


### PR DESCRIPTION
Added the `DreamZero` foundation model to the `README.md` file as requested in issue #49.
The entry includes:
-   **Model Name**: DreamZero
-   **Signature**: *I, L → A, V (Image, Language → Actions, Video)*
-   **Links**: Website, Paper, Code, Weights
-   **Notes**: Release date, WAM architecture, zero-shot generalization, cross-embodiment transfer, and real-time control capabilities.

This addresses the request in issue #49.
Verified links and content against the project website.

---
*PR created automatically by Jules for task [3365189099681507216](https://jules.google.com/task/3365189099681507216) started by @cagbal*