### PR TITLE
Verify papers from issues and fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,7 +1283,7 @@ Curated database of foundation models for robotics
 *I, P, G → A (Image, Proprioception, Goal Image → Actions)*
 
 - **Website**: [Google DeepMind Blog Post](https://deepmind.google/discover/blog/robocat-a-self-improving-robotic-agent/)
-- **Paper**: [RoboCat: A Self-Improving Generalist Agent for Robotic Manipulation](https://arxiv.org/abs/2306.11706)r
+- **Paper**: [RoboCat: A Self-Improving Generalist Agent for Robotic Manipulation](https://arxiv.org/abs/2306.11706)
 - **Notes**:
   - A multi-task, multi-embodiment generalist agent based on a decision transformer architecture (Gato).
   - Demonstrates a self-improvement loop: a trained model is fine-tuned for a new task, generates more data for that task, and this new data is used to train the next, more capable version of the generalist agent.


### PR DESCRIPTION
Checked all issues (open and closed) for requests to add papers. Verified that all requested papers (e.g., DreamZero, DynamicVLA, LingBot-VLA) are already present in the `README.md`.

Fixed a typo in the `RoboCat` entry where an extra 'r' was present after the paper link.

---
*PR created automatically by Jules for task [4276912836486985445](https://jules.google.com/task/4276912836486985445) started by @cagbal*