### PR TITLE
Update and Move DreamZero entry in README.md (Fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ Curated database of foundation models for robotics
 
 ## Main list 👇
 
+### **DreamZero**
+*I, L → A, V (Image, Language → Actions, Video)*
+
+* **Website**: [dreamzero0.github.io](https://dreamzero0.github.io/)
+* **Paper**: [DreamZero: World Action Models Are Zero-Shot Policies](https://arxiv.org/abs/2602.15922)
+* **Code**: [dreamzero0/dreamzero](https://github.com/dreamzero0/dreamzero)
+* **Weights**: [Hugging Face](https://huggingface.co/GEAR-Dreams/DreamZero-DROID)
+* **Notes**:
+    *   Released Feb 17, 2026.
+    *   World Action Model (WAM) that jointly predicts actions and videos.
+    *   Achieves strong zero-shot generalization to new tasks and environments (over 2x improvement vs VLAs).
+    *   Demonstrates efficient cross-embodiment transfer (adapts to new robot with 30 mins of play data).
+    *   Enables real-time closed-loop control at 7Hz via model and system optimizations (DreamZero-Flash).
+
+---
+
 ### **APEX**
 *I, P → A (Image, Proprioception → Actions)*
 
@@ -120,21 +136,6 @@ Curated database of foundation models for robotics
 
 ---
 
-### **DreamZero**
-*I, L → A, V (Image, Language → Actions, Video)*
-
-* **Website**: [dreamzero0.github.io](https://dreamzero0.github.io/)
-* **Paper**: [DreamZero: World Action Models Are Zero-Shot Policies](https://dreamzero0.github.io/DreamZero.pdf)
-* **Code**: [dreamzero0/dreamzero](https://github.com/dreamzero0/dreamzero)
-* **Weights**: [Hugging Face](https://huggingface.co/GEAR-Dreams/DreamZero-DROID)
-* **Notes**:
-    *   Released Feb 2026.
-    *   World Action Model (WAM) that jointly predicts actions and videos.
-    *   Achieves strong zero-shot generalization to new tasks and environments (over 2x improvement vs VLAs).
-    *   Demonstrates efficient cross-embodiment transfer (adapts to new robot with 30 mins of play data).
-    *   Enables real-time closed-loop control at 7Hz via model and system optimizations (DreamZero-Flash).
-
----
 
 ### **EgoActor**
 *I, L → A (Image, Language → Actions)*


### PR DESCRIPTION
Addresses issue #66 by updating the 'DreamZero' entry in `README.md`.
The entry was already present but misplaced and lacked specific details.
It has been moved to the top of the list (newest) and updated with the arXiv link and precise release date.

---
*PR created automatically by Jules for task [8943798537447873815](https://jules.google.com/task/8943798537447873815) started by @cagbal*