### PR TITLE
Add DreamDojo paper (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,12 @@ Curated database of foundation models for robotics
 * **Website**: [dreamdojo-world.github.io](https://dreamdojo-world.github.io/)
 * **Paper**: [DreamDojo: A Generalist Robot World Model from Large-Scale Human Videos](https://arxiv.org/abs/2602.06949)
 * **Code**: [NVIDIA/DreamDojo](https://github.com/NVIDIA/DreamDojo)
+* **Weights**: [nvidia/DreamDojo](https://huggingface.co/nvidia/DreamDojo)
 * **Notes**:
-    *   Released Feb 2026.
-    *   Foundation world model learning diverse interactions and dexterous controls from 44k hours of egocentric human videos.
-    *   Distillation pipeline accelerates to real-time 10.81 FPS.
+    *   Released Feb 2026 by NVIDIA.
+    *   Foundation world model learning diverse interactions and dexterous controls from 44k hours of egocentric human videos (`DreamDojo-HV` dataset).
+    *   Introduces **continuous latent actions** as a hardware-agnostic proxy to extract control signals from unlabelled human video.
+    *   Distillation pipeline accelerates autoregressive generation to real-time 10.81 FPS, enabling live teleoperation, policy evaluation, and model-based planning.
 
 #### **EgoActor**
 *I, L → A (Image, Language → Actions)*

--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ Curated database of foundation models for robotics
     *   Stage 2: Spatially guided action post-training with spatial prompting.
     *   Substantial improvements on Google Robot and WidowX Robot tasks.
 
+#### **DreamDojo**
+*Vid, A → Vid' (Video, Actions → Future Video) [World Model]*
+
+* **Website**: [dreamdojo-world.github.io](https://dreamdojo-world.github.io/)
+* **Paper**: [DreamDojo: A Generalist Robot World Model from Large-Scale Human Videos](https://arxiv.org/abs/2602.06949)
+* **Code**: [NVIDIA/DreamDojo](https://github.com/NVIDIA/DreamDojo)
+* **Notes**:
+    *   Released Feb 2026.
+    *   Foundation world model learning diverse interactions and dexterous controls from 44k hours of egocentric human videos.
+    *   Distillation pipeline accelerates to real-time 10.81 FPS.
+
 #### **EgoActor**
 *I, L → A (Image, Language → Actions)*
 


### PR DESCRIPTION
Adds the DreamDojo paper to the README.md in chronological order according to its arXiv release date. Resolves #125.

---
*PR created automatically by Jules for task [10314639106447838230](https://jules.google.com/task/10314639106447838230) started by @cagbal*