### PR TITLE
Add LDA-1B paper requested in issue #142

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Curated database of foundation models for robotics
 
 ### 🚀 2026 Models
 
+#### **LDA-1B**
+*I, L → A (Image, Language → Actions)*
+
+* **Website**: [pku-epic.github.io/LDA](https://pku-epic.github.io/LDA/)
+* **Paper**: [LDA-1B: Scaling Latent Dynamics Action Model via Universal Embodied Data Ingestion](https://arxiv.org/abs/2602.12215)
+* **Code**: [PKU-EPIC/LDA](https://github.com/PKU-EPIC/LDA)
+* **Notes**:
+    *   Released Feb 2026.
+    *   Scaling Latent Dynamics Action Model via Universal Embodied Data Ingestion.
+
+
 #### **$\pi_{0.7}$ (Pi 0.7)**
 *I, L → A (Image, Language → Actions)*
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Curated database of foundation models for robotics
 * **Code**: [PKU-EPIC/LDA](https://github.com/PKU-EPIC/LDA)
 * **Notes**:
     *   Released Feb 2026.
-    *   Scaling Latent Dynamics Action Model via Universal Embodied Data Ingestion.
+    *   Jointly learns dynamics, policy, and visual forecasting.
+    *   Assembled EI-30k, an embodied interaction dataset comprising over 30k hours of trajectories.
+    *   Uses a structured DINO latent space for scalable dynamics learning.
+    *   Employs a multi-modal diffusion transformer to handle asynchronous vision and action streams.
+    *   Outperforms prior methods (like $\pi_{0.5}$) on contact-rich, dexterous, and long-horizon tasks.
 
 
 #### **$\pi_{0.7}$ (Pi 0.7)**


### PR DESCRIPTION
Adds LDA-1B from https://pku-epic.github.io/LDA/ to the list of 2026 Models, resolving issue #142

---
*PR created automatically by Jules for task [11107500837504190016](https://jules.google.com/task/11107500837504190016) started by @cagbal*