### PR TITLE
Add MINT from Issue #186

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Curated database of foundation models for robotics
 * **Data**: [Hugging Face](https://huggingface.co/collections/allenai/molmoact2-datasets)
 
 
+
+#### **MINT**
+*I, L → A (Image, Language → Actions)*
+
+* **Website**: [renming-huang.github.io/MINT](https://renming-huang.github.io/MINT/)
+* **Paper**: [Mimic Intent, Not Just Trajectories](https://arxiv.org/abs/2602.08602)
+* **Code**: [RenMing-Huang/MINT](https://github.com/RenMing-Huang/MINT)
+* **Notes**:
+    *   Released Feb 2026.
+    *   Proposes explicitly disentangling behavior intent from execution details in end-to-end imitation learning (MINT).
+    *   Achieves this via multi-scale frequency-space tokenization, forcing a spectral decomposition of action chunk representation.
+    *   Learns action tokens with a multi-scale coarse-to-fine structure, capturing low-frequency global structure with the coarsest token and high-frequency details with finer tokens.
+    *   Yields an abstract Intent token for planning and transfer, and multi-scale Execution tokens for precise adaptation.
+    *   Enables one-shot transfer of skills by injecting the Intent token from a demonstration into the autoregressive generation process.
+
 #### **LDA-1B**
 *I, L → A (Image, Language → Actions)*
 


### PR DESCRIPTION
Fixes #186\n\nSummary:\n- Issue #186: https://github.com/RenMing-Huang/MINT. Paper requested: Mimic Intent, Not Just Trajectories (MINT). Already included: No. Existing PR covered it: No. Change made: Added MINT to README.md under 2026 Models. PR link: Opened PR for this issue.\n- Issue #183: Multimodal Diffusion Forcing. Skipped as it is handled by PR #184.\n- Issue #179: Training-Free Dense Hand Contact Estimation. Skipped as it is handled by PR #180.\n- Issue #178: Beyond Action Residuals. Skipped as it is handled by PR #180.\n- Issue #177: ExpertGen. Skipped as it is handled by PR #180.\n- Issue #170: Realtime-VLA FLASH. Skipped as it is handled by PR #171.

---
*PR created automatically by Jules for task [17056584671324178963](https://jules.google.com/task/17056584671324178963) started by @cagbal*