### PR TITLE
Add Gamma-World from Issue #191

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Curated database of foundation models for robotics
 
 ### 🚀 2026 Models
 
+#### **Gamma-World**
+*A → I (Actions → Image)*
+
+Website: [research.nvidia.com/labs/sil/projects/gamma-world](https://research.nvidia.com/labs/sil/projects/gamma-world/)
+Code: [github.com/nv-tlabs/Gamma-World](https://github.com/nv-tlabs/Gamma-World)
+Paper: [Gamma-World: Generative Multi-Agent World Modeling Beyond Two Players](https://arxiv.org/abs/2605.28816)
+
+**Notes:**
+* Released May 2026.
+* Generative multi-agent world model that simulates environments for multiple independently controllable agents.
+* Introduces Simplex Rotary Agent Encoding for permutation-symmetric agent representation and Sparse Hub Attention for efficient communication.
+* Scales from virtual multiplayer games to real-world multi-robot coordination while maintaining shared-world consistency.
+
 #### **Agentic-VLA**
 *I, L → A (Image, Language → Actions)*
 


### PR DESCRIPTION
Fixes #191\n\nSummary:\n- Issue #191: Gamma-World. Paper requested: Gamma-World: Generative Multi-Agent World Modeling Beyond Two Players. Already included: No. Existing PR covered it: No. Change made: Added to the top of the 2026 Models list in README.md with paper, website, and code links. PR link: Opened PR for this issue.\n- Skipped: #183, #179, #178, #177 (All are covered by existing open PRs).

---
*PR created automatically by Jules for task [11570441405778906650](https://jules.google.com/task/11570441405778906650) started by @cagbal*