### PR TITLE
Add LingBot-Depth and ASPIRE from Issue #233 and #232

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ Curated database of foundation models for robotics
 
 ### 🚀 2026 Models
 
+#### **LingBot-Depth**
+*I, D → D, P (Image, Depth → Depth, Points)*
+
+* **Website**: [technology.robbyant.com/lingbot-depth](https://technology.robbyant.com/lingbot-depth)
+* **Code**: [robbyant/lingbot-depth](https://github.com/robbyant/lingbot-depth)
+* **Paper**: [Masked Depth Modeling for Spatial Perception](https://arxiv.org/abs/2601.17895)
+* **Notes**:
+    *   Released Jan 2026.
+    *   Transforms incomplete and noisy depth sensor data into high-quality, metric-accurate 3D measurements.
+    *   Jointly aligns RGB appearance and depth geometry in a unified latent space via cross-modal attention.
+    *   Serves as a powerful spatial perception foundation for robot learning and 3D vision applications, like 4D point tracking and dexterous manipulation.
+
+#### **ASPIRE**
+*I, L → A (Image, Language → Actions)*
+
+* **Website**: [research.nvidia.com/labs/gear/aspire/](https://research.nvidia.com/labs/gear/aspire/)
+* **Paper**: [ASPIRE: Agentic Skills Discovery for Robotics](https://research.nvidia.com/labs/gear/aspire/assets/Aspire.pdf)
+* **Notes**:
+    *   Released 2026.
+    *   A self-improving continual learning system for robotics that autonomously writes and refines code-as-policy robot control programs from execution feedback.
+    *   Operates in an open-ended learning loop with a closed-loop robot execution engine, a continually expanding skill library, and an evolutionary search procedure.
+    *   Demonstrates strong zero-shot transfer to unseen long-horizon tasks and real-robot cross-embodiment skill transfer.
+
 #### **Improving Robotic Generalist Policies via Flow Reversal Steering**
 *I, L → A (Image, Language → Actions)*
 


### PR DESCRIPTION
Summary:\nIssue number and title: 233 - https://github.com/Robbyant/lingbot-depth, 232 - https://research.nvidia.com/labs/gear/aspire/\nPaper(s) requested: LingBot-Depth, ASPIRE\nWhether the paper was already included: No\nWhether an existing PR already covered it: No\nWhat change you made: Added LingBot-Depth and ASPIRE under 2026 Models in README.md\nPR link: (Will be generated upon submission)\nAny issues you skipped and why: None\n\nFixes #232\nFixes #233

---
*PR created automatically by Jules for task [7612883019678019924](https://jules.google.com/task/7612883019678019924) started by @cagbal*